### PR TITLE
fix: BRI slider live debounced, test dismiss timing

### DIFF
--- a/tools/dpx_test.sh
+++ b/tools/dpx_test.sh
@@ -197,9 +197,9 @@ _post /api/notify '{"text":"DISMISS ME NOW","color":"#FF8800","duration":5}' > /
 _wait 1
 vis "Orange 'DISMISS ME NOW' scrolling — confirm you see it"
 resp=$(_post /api/notify/dismiss '{}'); assert_ok "$resp" "Dismiss API"
-_wait 1
+_wait 2  # wait for display to visibly clear before asking
 vis "Display cleared immediately after dismiss (nothing scrolling)"
-_wait 2  # let dismiss settle before next notify
+_wait 1  # let dismiss settle before next notify
 
 # 3. Finite repeat — must scroll exactly 2× then vanish on its own
 _post /api/notify '{"text":"SCROLL TWICE AND STOP","color":"#00FFFF","repeat":2,"duration":5}' > /dev/null

--- a/usermods/dpx_matrix/dpx_html.h
+++ b/usermods/dpx_matrix/dpx_html.h
@@ -798,8 +798,7 @@ select option{background:#222}
 <div class="card">
 <h2>Display &amp; Indicators</h2>
 <label>Brightness</label>
-<div class="row"><input type="range" id="bri" min="0" max="255" value="128" oninput="document.getElementById('bri_v').textContent=this.value"><span id="bri_v" style="min-width:28px;text-align:right">128</span></div>
-<button onclick="sendBri()" style="margin-top:6px">Set Brightness</button>
+<div class="row"><input type="range" id="bri" min="0" max="255" value="128" oninput="document.getElementById('bri_v').textContent=this.value;sendBri()"><span id="bri_v" style="min-width:28px;text-align:right">128</span></div>
 <hr>
 <div class="row" style="margin-top:4px">
   <button onclick="apiPost('/api/power',{power:true})">&#9675; Power On</button>
@@ -998,7 +997,7 @@ function deleteCustomApp(){
   fetch("/api/custom?name="+encodeURIComponent(name),{method:"POST"}).then(function(){toast("App removed");setTimeout(loadLoop,600);});
 }
 function sendInd(n){apiPost("/api/indicator"+n,{color:h2r(document.getElementById("i"+n+"c").value),blink:+document.getElementById("i"+n+"b").value,fade:+document.getElementById("i"+n+"f").value});}
-function sendBri(){apiPost("/api/settings",{BRI:+document.getElementById("bri").value});}
+var _briT=null;function sendBri(){clearTimeout(_briT);_briT=setTimeout(function(){apiPost("/api/settings",{BRI:+document.getElementById("bri").value});},300);}
 function switchApp(){var n=document.getElementById("sw_app").value;if(!n){toast("Enter app name",false);return;}apiPost("/api/switch",{name:n});}
 function loadListeners(){
   var el=document.getElementById("listener_list");if(!el)return;


### PR DESCRIPTION
- **#32**: BRI slider now debounced (300ms) and sends live on drag — no button needed\n- **#57**: Added 2s pause after dismiss before 'display cleared' vis() check\n- **#34**: Already in test suite — closed as already fixed